### PR TITLE
Add `go_default_library` alias

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 # gazelle:exclude c-deps/or-tools
 # gazelle:exclude c-deps/abseil-cpp
 # gazelle:build_tags bazel
+# gazelle:go_naming_convention import_alias
 gazelle(
     name = "gazelle",
     prefix = "github.com/irfansharif/solver",
@@ -48,4 +49,10 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":solver",
+    visibility = ["//visibility:public"],
 )

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -37,3 +37,9 @@ cc_library(
         "@ortools//ortools/sat:sat_parameters_cc_proto",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":internal",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/pb/BUILD.bazel
+++ b/internal/pb/BUILD.bazel
@@ -24,3 +24,9 @@ go_library(
     importpath = "github.com/irfansharif/solver/internal/pb",
     visibility = ["//:__subpackages__"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":pb",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/testutils/BUILD.bazel
+++ b/internal/testutils/BUILD.bazel
@@ -14,3 +14,9 @@ go_library(
         "//internal/testutils/parser/ast",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":testutils",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/testutils/bazel/BUILD.bazel
+++ b/internal/testutils/bazel/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = ["@com_github_stretchr_testify//require"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":bazel",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/testutils/parser/BUILD.bazel
+++ b/internal/testutils/parser/BUILD.bazel
@@ -29,3 +29,9 @@ go_test(
         "@org_golang_x_exp//ebnf",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":parser",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/testutils/parser/ast/BUILD.bazel
+++ b/internal/testutils/parser/ast/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = ["//:solver"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":ast",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/testutils/parser/lexer/BUILD.bazel
+++ b/internal/testutils/parser/lexer/BUILD.bazel
@@ -19,3 +19,9 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":lexer",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/testutils/parser/token/BUILD.bazel
+++ b/internal/testutils/parser/token/BUILD.bazel
@@ -9,3 +9,9 @@ go_library(
     importpath = "github.com/irfansharif/solver/internal/testutils/parser/token",
     visibility = ["//:__subpackages__"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":token",
+    visibility = ["//:__subpackages__"],
+)


### PR DESCRIPTION
unfortunately our version of bazel/gazelle tooling still expects the `go_default_library` target convention, so adding aliases using `# gazelle:go_naming_convention import_alias` 

also, thank you for this project 👍 

cc: @irfansharif